### PR TITLE
fix: use timing safe password comparison

### DIFF
--- a/src/authentication.php
+++ b/src/authentication.php
@@ -46,7 +46,7 @@ function attempt_login(array $data = []): bool|string
         return false;
     }
 
-    if (USERS[$data['username']]['password'] !== $data['password']) {
+    if (!hash_equals(USERS[$data['username']]['password'], $data['password'])) {
         // wrong password
         return false;
     }


### PR DESCRIPTION
It replaces normal string comparison with `hash_equals` to prevent potential [timing attacks](https://en.wikipedia.org/wiki/Timing_attack).